### PR TITLE
Add support for minor versions of 6.0 as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "mockery/mockery": "~0.9|~1.0",
         "phpunit/phpunit": "5.5.*|6.0.*|7.0.*|^8.0",
-        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0Add support for minor versions of 6.0 as well"
+        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.0.*"
+        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9|~1.0",
         "phpunit/phpunit": "5.5.*|6.0.*|7.0.*|^8.0",
-        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.0.*"
+        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0Add support for minor versions of 6.0 as well"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Laravel 6.1 was released today, but the constraint prevents installing it.

To the best of my knowledge, we should allow minor versions as well with the changed semver versioning from 6.0 and up.

See https://github.com/laravel/framework/releases/tag/v6.1.0