### PR TITLE
Don't scope by removed tenant

### DIFF
--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -59,14 +59,14 @@ class TenantManager
 
      /**
      * Check if the tenant management is enabled
-     * 
+     *
      * @return bool
      */
     public function isEnabled() : bool
     {
         return $this->enabled;
     }
-    
+
     /**
      * Add a tenant to scope by.
      *
@@ -156,6 +156,13 @@ class TenantManager
 
         $this->modelTenants($model)->each(function ($id, $tenant) use ($model) {
             $model->addGlobalScope($tenant, function (Builder $builder) use ($tenant, $id, $model) {
+                /**
+                 * In case tenant is removed after this scope is created
+                 * we don't want to scope by it
+                 */
+                if (!$this->tenants->contains($tenant)) {
+                    return;
+                }
                 $builder->where($model->getQualifiedTenant($tenant), '=', $this->getTenantId($tenant));
             });
         });
@@ -174,6 +181,14 @@ class TenantManager
                 }
 
                 $model->addGlobalScope($tenant, function (Builder $builder) use ($tenant, $id, $model) {
+                    /**
+                     * In case tenant is removed after this scope is created
+                     * we don't want to scope by it
+                     */
+                    if (!$this->tenants->contains($tenant)) {
+                        return;
+                    }
+
                     $builder->where($model->getQualifiedTenant($tenant), '=', $this->getTenantId($tenant));
                 });
             });


### PR DESCRIPTION
Hi, 
thanks for keeping this package maintained. You saved lots of time for us and our project. 

We've got one issue though. In our project we use `applyTenantScopesToDeferredModels()` method at the beginning of the app life circle. Then somewhere in the middle of that life circle we call `\Landlord::removeTenant('tenant_id')` which means we don't want to scope by a `tenant_id` for all the models we're going to use after the `removeTenant` call. But instead of not scoping we're getting exception saying that `$tenant must be a string key or an instance of \Illuminate\Database\Eloquent\Model`. It's all because `tenant_id` isn't available in `tenants` property of `TenantManager` class anymore but the scope was created already and it expects that `tenant_id` available. 

This pull request fixes the issue. Let me know if the issue description isn't clear or the fix has other issues I didn't notice. 

Thanks